### PR TITLE
Auth 37 add verification email html design

### DIFF
--- a/api/models/export_types/email_types/ecom_email.py
+++ b/api/models/export_types/email_types/ecom_email.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Optional, List
 
+from django.template.loader import render_to_string
 from pydantic import BaseModel
 
 from api.models.export_types.export_user import ExportECOMUser
@@ -21,25 +22,19 @@ class ECOMEmailMessage(BaseModel):
     reply_to: Optional[str] = None
 
     @classmethod
-    def create_otp_email_by_user(
-        cls, user: ExportECOMUser, otp: str
-    ) -> ECOMEmailMessage:
-        return cls(
-            subject="Shoopixa User Verification",
-            body=f"Your OTP is: {otp}",
-            from_email=default_email,
-            to=[user.email],
-        )
-
-    @classmethod
-    def create_otp_email_by_user_email(
-        cls, user_email: str, otp: str
+    def create_password_reset_email_by_user_email(
+        cls, user_email: str, reset_url: str
     ) -> ECOMEmailMessage:
         if user_email:
-            if ECOMUser.objects.filter(email=user_email).count() > 0:
+            if validate_user_email(user_email).is_validated:
+                user = ExportECOMUser(
+                    **ECOMUser.objects.get(email=user_email).model_to_dict()
+                )
+                context = {"fname": user.fname, "reset_url": reset_url}
+                html_content = render_to_string("password_reset_email.html", context)
                 return cls(
-                    subject="Shoopixa User Verification",
-                    body=f"Your OTP is: {otp}",
+                    subject="Shoopixa User Password Reset",
+                    body=html_content,
                     from_email=default_email,
                     to=[user_email],
                 )
@@ -49,15 +44,20 @@ class ECOMEmailMessage(BaseModel):
             raise ValueError
 
     @classmethod
-    def create_password_reset_email_by_user_email(
-        cls, user_email: str, reset_url: str
+    def create_otp_html_email_by_user_email(
+        cls, user_email: str, otp: str
     ) -> ECOMEmailMessage:
         if user_email:
-            if validate_user_email(user_email).is_validated:
+            if ECOMUser.objects.filter(email=user_email).count() > 0:
+                user = ExportECOMUser(
+                    **ECOMUser.objects.get(email=user_email).model_to_dict()
+                )
+                context = {"fname": user.fname, "otp": otp}
+                html_content = render_to_string("otp_email.html", context)
                 return cls(
-                    subject="Shoopixa User Password Reset",
-                    body=f"Click the following link to reset your password: {reset_url}",
-                    from_email=default_email,
+                    subject="Shoopixa User Verification",
+                    body=html_content,
+                    from_email="Shoppixa",
                     to=[user_email],
                 )
             else:

--- a/api/services/email_services/email_services.py
+++ b/api/services/email_services/email_services.py
@@ -1,27 +1,8 @@
 from django.core.mail import EmailMessage
 from api.models.export_types.email_types.ecom_email import ECOMEmailMessage
-from api.models.export_types.export_user import ExportECOMUser
 
 
 class EmailServices:
-    @staticmethod
-    def send_otp_email_by_user(user: ExportECOMUser, otp: str) -> str:
-        email: ECOMEmailMessage = ECOMEmailMessage.create_otp_email_by_user(
-            user=user, otp=otp
-        )
-        email_message: EmailMessage = EmailMessage(**email.model_dump())
-        email_message.send()
-        return "OK"
-
-    @staticmethod
-    def send_otp_email_by_user_email(user_email: str, otp: str) -> str:
-        email: ECOMEmailMessage = ECOMEmailMessage.create_otp_email_by_user_email(
-            user_email=user_email, otp=otp
-        )
-        email_message: EmailMessage = EmailMessage(**email.model_dump())
-        email_message.send()
-        return "OK"
-
     @staticmethod
     def send_password_reset_email_by_user_email(user_email: str, reset_url: str) -> str:
         email: ECOMEmailMessage = (
@@ -30,5 +11,16 @@ class EmailServices:
             )
         )
         email_message: EmailMessage = EmailMessage(**email.model_dump())
+        email_message.content_subtype = "html"
+        email_message.send()
+        return "OK"
+
+    @staticmethod
+    def send_otp_email_by_user_email(user_email: str, otp: str) -> str:
+        email: ECOMEmailMessage = ECOMEmailMessage.create_otp_html_email_by_user_email(
+            user_email=user_email, otp=otp
+        )
+        email_message: EmailMessage = EmailMessage(**email.model_dump())
+        email_message.content_subtype = "html"
         email_message.send()
         return "OK"

--- a/api/templates/otp_email.html
+++ b/api/templates/otp_email.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head>
+<meta name="viewport" content="width=device-width" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Welcome to Shoppixa</title>
+
+
+<style type="text/css">
+img {
+max-width: 100%;
+}
+body {
+-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em;
+}
+body {
+background-color: #f6f6f6;
+}
+@media only screen and (max-width: 640px) {
+  body {
+    padding: 0 !important;
+  }
+  h1 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h2 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h3 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h4 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h1 {
+    font-size: 22px !important;
+  }
+  h2 {
+    font-size: 18px !important;
+  }
+  h3 {
+    font-size: 16px !important;
+  }
+  .container {
+    padding: 0 !important; width: 100% !important;
+  }
+  .content {
+    padding: 0 !important;
+  }
+  .content-wrap {
+    padding: 10px !important;
+  }
+  .invoice {
+    width: 100% !important;
+  }
+}
+</style>
+</head>
+
+<body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+
+<table class="body-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+        <td class="container" width="600" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;" valign="top">
+            <div class="content" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 20px;">
+                <table class="main" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 3px; background-color: #fff; margin: 0; border: 1px solid #e9e9e9;" bgcolor="#fff"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
+                            <meta itemprop="name" content="Confirm Email" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" /><table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        Greetings from Shoopixa Team,
+                                    </td>
+                                </tr><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        Hello {{fname}}, Welcome to Shoppixa. Your account has been created successfully. {{ otp }} is your One Time Password (OTP) for your account verification with Shoppixa. The OTP is valid for 15 minutes.
+                                    </td>
+                                </tr><tr style="text-align: center; font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        <p class="btn-primary" itemprop="url" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">{{ otp }}</p>
+                                    </td>
+                                </tr><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    Thank You,<br>
+                    &mdash; Shoppixa Team
+                                    </td>
+                                </tr></table></td>
+                    </tr></table><div class="footer" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
+                    <table width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">Follow <a href="http://twitter.com/mail_gun" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">@ridofreak</a> on Twitter.</td>
+                        </tr></table></div></div>
+        </td>
+        <td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+    </tr></table></body>
+</html>

--- a/api/templates/password_reset_email.html
+++ b/api/templates/password_reset_email.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head>
+<meta name="viewport" content="width=device-width" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Shoppixa Password Reset</title>
+
+
+<style type="text/css">
+img {
+max-width: 100%;
+}
+body {
+-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em;
+}
+body {
+background-color: #f6f6f6;
+}
+@media only screen and (max-width: 640px) {
+  body {
+    padding: 0 !important;
+  }
+  h1 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h2 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h3 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h4 {
+    font-weight: 800 !important; margin: 20px 0 5px !important;
+  }
+  h1 {
+    font-size: 22px !important;
+  }
+  h2 {
+    font-size: 18px !important;
+  }
+  h3 {
+    font-size: 16px !important;
+  }
+  .container {
+    padding: 0 !important; width: 100% !important;
+  }
+  .content {
+    padding: 0 !important;
+  }
+  .content-wrap {
+    padding: 10px !important;
+  }
+  .invoice {
+    width: 100% !important;
+  }
+}
+</style>
+</head>
+
+<body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+
+<table class="body-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+        <td class="container" width="600" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;" valign="top">
+            <div class="content" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 20px;">
+                <table class="main" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 3px; background-color: #fff; margin: 0; border: 1px solid #e9e9e9;" bgcolor="#fff"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
+                            <meta itemprop="name" content="Confirm Email" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" /><table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        Greetings from Shoopixa Team,
+                                    </td>
+                                </tr><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        Hello {{fname}}, We received a request to reset the password for the Shoppixa account associated with this e-mail address. Click the button below to reset your password using our secure server:
+                                    </td>
+                                </tr><tr style="text-align: center; font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        <a href={{reset_url}} class="btn-primary" itemprop="url" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Reset Password</a>
+                                    </td>
+                                </tr><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        Thank You,<br>&mdash; Shoppixa Team
+                                    </td>
+                                </tr></table></td>
+                    </tr></table><div class="footer" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
+                    <table width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">Follow <a href="http://twitter.com/mail_gun" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">@ridofreak</a> on Twitter.</td>
+                        </tr></table></div></div>
+        </td>
+        <td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+    </tr></table></body>
+</html>

--- a/api/views/user_views/create_user.py
+++ b/api/views/user_views/create_user.py
@@ -217,13 +217,13 @@ class CreateUsersView(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content_type="application/json",
             )
-        except Exception as e:
-            logging.warning(f"InternalServerError: {e}")
-            return Response(
-                data={
-                    "successMessage": None,
-                    "errorMessage": f"InternalServerError: {e}",
-                },
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                content_type="application/json",
-            )
+        # except Exception as e:
+        #     logging.warning(f"InternalServerError: {e}")
+        #     return Response(
+        #         data={
+        #             "successMessage": None,
+        #             "errorMessage": f"InternalServerError: {e}",
+        #         },
+        #         status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #         content_type="application/json",
+        #     )


### PR DESCRIPTION
### Overview

> JIRA Ticket:[ AUTH - 37 ](https://shoppixa.atlassian.net/browse/AUTH-37)

**What was the problem:**
We needed desgined HTML for Email contents,

**How was this solved:**
We have added html contents.

**Features:**
- will send html content email.

**Services to be impacted:**
- `auth`

**Example Code or Screenshot:**
```
Example Code or Screenshot
```
![image](https://github.com/KoushikMallik-developer/auth-v2/assets/62284117/9621cdb0-9f88-486e-8352-a66eef7946b6)
![image](https://github.com/KoushikMallik-developer/auth-v2/assets/62284117/d334be4d-9c89-45cf-b7d9-68fb0b2ec6ac)

**_For the PR Creator_**

- [x] Filled out entirely of PR Template.
- [x] Changes meet acceptance criteria defined in ticket.
- [ ] Unit Tests Passed. :tada:
- [x] Tested on DEV Env.
- [ ] Tested on QA Env.
